### PR TITLE
Removal the login requirements for loading data

### DIFF
--- a/src/lib220.ts
+++ b/src/lib220.ts
@@ -253,16 +253,11 @@ function lib220(config) {
       return runner.pauseImmediate(() => {
         const userEmail = localStorage.getItem('userEmail'),
               sessionId = localStorage.getItem('sessionId');
-        if (userEmail === null || sessionId === null) {
-          if (runnerResult.value.isRunning) {
-            runner.continueImmediate({
-              type: 'exception',
-              stack: [],
-              value: new Error(`User is not logged in`)
-            });
-          } else {
-            runnerResult.value.onStopped();
-          }
+        if (userEmail === null) {
+          userEmail = "anonymousUser"
+        }
+         if (sessionId === null) {
+          sessionId = "anonymousUser"
         }
         const encodedURL = encodeURIComponent(url);
         const baseUrl = config.baseUrl;


### PR DESCRIPTION
The current implementation will throw an error while a non-loggedin user tries to use a function like lib220.loadImageFromURL(), the irony of that is, that it still goes through and the loads the image, and creates the blob. The only thing that stops a user then is the throwing of an exception. With these same modifications I was able to successfully use the ocelot IDE for manipulating images from URLs without having an account. This is a good usability feature as people that are not in 220, might still want to take advantage of ocelot and the lib220 library.